### PR TITLE
Messaging changes

### DIFF
--- a/test/messageHandler.integration.ts
+++ b/test/messageHandler.integration.ts
@@ -379,7 +379,7 @@ describe("Core Logic", () => {
     };
     const response = buildResponse();
     await messageHandler.handle(buildRequest(message), response);
-
+    await new Promise<void>((res) => setImmediate(res)); // Wait for the message to send since it's async
     const lastCode = await messageHandler.models.entity.getLastCode(entityId as string);
     expect(lastCode).to.equal("TEST1");
 
@@ -390,7 +390,7 @@ describe("Core Logic", () => {
     };
     const response2 = buildResponse();
     await messageHandler.handle(buildRequest(message2), response2);
-
+    await new Promise<void>((res) => setImmediate(res)); // Wait for the message to send since it's async
     const lastCode2 = await messageHandler.models.entity.getLastCode(entityId as string);
     expect(lastCode2).to.equal("TEST2");
   });

--- a/test/messageHandler.integration.ts
+++ b/test/messageHandler.integration.ts
@@ -179,12 +179,17 @@ describe("Core Logic", () => {
 
     expect(response.send.calledOnceWith(twimlResponse(responses.SEND_CODE.replace("%CODE%", "TEST").replace("%COUNT%", "1")))).to.be.true;
 
-    expect(
-      sendStub.calledWithExactly(
-        normalUser.phoneNumber,
-        responses.DEFAULT_MESSAGE
-      )
-    );
+    await new Promise<void>((res) => {
+      setTimeout(() => {
+        expect(
+          sendStub.calledWithExactly(
+            normalUser.phoneNumber,
+            responses.DEFAULT_MESSAGE
+          )
+        );
+        res();
+      }, 100); // Wait for the message to send since it's async
+    });
   });
 
   it("should send a message to subscriber when CUSTOM CODE is sent by admin", async () => {
@@ -197,9 +202,13 @@ describe("Core Logic", () => {
     await messageHandler.handle(buildRequest(message), response);
 
     expect(response.send.calledOnceWith(twimlResponse(responses.CUSTOM_MESSAGE.replace("%COUNT%", "1")))).to.be.true;
-
-    expect(sendStub.calledWithExactly(entity?.accountPhoneNumber, normalUser.phoneNumber, "Hello world!")).to.be.true;
-    expect(!sendStub.calledWithExactly(entity?.accountPhoneNumber, admin.phoneNumber, "Hello world!")).to.be.true;
+    await new Promise<void>((res) => {
+      setTimeout(() => {
+        expect(sendStub.calledWithExactly(entity?.accountPhoneNumber, normalUser.phoneNumber, "Hello world!")).to.be.true;
+        expect(!sendStub.calledWithExactly(entity?.accountPhoneNumber, admin.phoneNumber, "Hello world!")).to.be.true;
+        res();
+      }, 100); // Wait for the message to send since it's async
+    });
   });
 
   it("should send a message to all when CUSTOM ALL is sent by admin", async () => {
@@ -212,9 +221,13 @@ describe("Core Logic", () => {
     await messageHandler.handle(buildRequest(message), response);
 
     expect(response.send.calledOnceWith(twimlResponse(responses.CUSTOM_MESSAGE.replace("%COUNT%", "2")))).to.be.true;
-
-    expect(sendStub.calledWithExactly(entity?.accountPhoneNumber, normalUser.phoneNumber, "Hello world!")).to.be.true;
-    expect(sendStub.calledWithExactly(entity?.accountPhoneNumber, admin.phoneNumber, "Hello world!")).to.be.true;
+    await new Promise<void>((res) => {
+      setTimeout(() => {
+        expect(sendStub.calledWithExactly(entity?.accountPhoneNumber, normalUser.phoneNumber, "Hello world!")).to.be.true;
+        expect(sendStub.calledWithExactly(entity?.accountPhoneNumber, admin.phoneNumber, "Hello world!")).to.be.true;
+        res();
+      }, 100); // Wait for the message to send since it's async
+    });
   });
 
   it("should return an error when message name is not known", async () => {
@@ -227,10 +240,14 @@ describe("Core Logic", () => {
     await messageHandler.handle(buildRequest(message), response);
 
     expect(response.send.calledOnceWith(twimlResponse(responses.UNKNOWN_MSG_NAME))).to.be.true;
-
-    expect(
-      sendStub.notCalled
-    );
+    await new Promise<void>((res) => {
+      setTimeout(() => {
+        expect(
+          sendStub.notCalled
+        );
+        res();
+      }, 100); // Wait for the message to send since it's async
+    });
   });
 
   it("should return all message names when GET MESSAGE NAMES is sent by admin", async () => {
@@ -341,12 +358,17 @@ describe("Core Logic", () => {
     expect(response2.send.calledOnceWith(twimlResponse(responses.NAMED_MESSAGE.replace("%NAME%", "NAME").replace("%COUNT%", "1")))).to.be.true;
 
     const namedMessage = await messageHandler.models.entity.getMessage(entityId as string, "NAME");
-    expect(
-      sendStub.calledWithExactly(
-        normalUser.phoneNumber,
-        namedMessage
-      )
-    );
+    await new Promise<void>((res) => {
+      setTimeout(() => {
+        expect(
+          sendStub.calledWithExactly(
+            normalUser.phoneNumber,
+            namedMessage
+          )
+        );
+        res();
+      }, 100); // Wait for the message to send since it's async
+    });
   });
 
   it("should set an entity's last code when an admin sends a campaign", async () => {
@@ -633,8 +655,13 @@ describe("Core Logic", () => {
     await messageHandler.handle(buildRequest(adminMessage), adminResponse);
     const result = responses.SEND_CODE.replace("%CODE%", "TEST1").replace("%COUNT%", "0");
     expect(adminResponse.send.calledOnceWith(twimlResponse(result))).to.be.true;
-    expect(sendStub.callCount).to.equal(0);
-
+    
+    await new Promise<void>((res) => {
+      setTimeout(() => {
+        expect(sendStub.callCount).to.equal(0);
+        res();
+      }, 100); // Wait for the message to send since it's async
+    });
     const start = {
       Body: "start",
       From: normalUser.phoneNumber,

--- a/test/messageHandler.unit.ts
+++ b/test/messageHandler.unit.ts
@@ -105,7 +105,12 @@ describe("decipherMessage", () => {
       await messageHandler.decipherMessage(reqCtx, req);
 
       expect(findAllStub.calledOnceWithExactly({entityId: "00001", campaignCode: "LOC1"}));
-      expect(sendStub.callCount).to.equal(3);
+      await new Promise<void>((res) => {
+        setTimeout(() => {
+          expect(sendStub.callCount).to.equal(3);
+          res();
+        }, 100);
+      });
     });
 
     it("should call addAdmin when message is ADD ADMIN", async () => {
@@ -290,10 +295,15 @@ describe("decipherMessage", () => {
       await messageHandler.decipherMessage(reqCtx, req);
 
       expect(findAllStub.calledOnceWithExactly({entityId: "00001", campaignCode: "LOC1"}));
-      expect(sendStub.callCount).to.equal(3);
-      expect(sendStub.calledWith("+1234567890", "Hello world!"));
-      expect(sendStub.calledWith("+2234567890", "Hello world!"));
-      expect(sendStub.calledWith("+3234567890", "Hello world!"));
+      await new Promise<void>((res) => {
+        setTimeout(() => {
+          expect(sendStub.callCount).to.equal(3);
+          expect(sendStub.calledWith("+1234567890", "Hello world!"));
+          expect(sendStub.calledWith("+2234567890", "Hello world!"));
+          expect(sendStub.calledWith("+3234567890", "Hello world!"));
+          res();
+        }, 100);
+      });
     });
 
     it("should call EntityModel.setDefaultMessage when message is SET MESSAGE and setting exists", async () => {
@@ -550,10 +560,15 @@ describe("decipherMessage", () => {
 
       expect(findAllStub.calledOnceWithExactly({entityId: "00001", campaignCode: "LOC1"}));
       expect(getMessageStub.calledOnceWithExactly("00001", "MSG1"));
-      expect(sendStub.callCount).to.equal(3);
-      expect(sendStub.calledWith("+1234567890", "This is message 1"));
-      expect(sendStub.calledWith("+2234567890", "This is message 1"));
-      expect(sendStub.calledWith("+3234567890", "This is message 1"));
+      await new Promise<void>((res) => {
+        setTimeout(() => {
+          expect(sendStub.callCount).to.equal(3);
+          expect(sendStub.calledWith("+1234567890", "This is message 1"));
+          expect(sendStub.calledWith("+2234567890", "This is message 1"));
+          expect(sendStub.calledWith("+3234567890", "This is message 1"));
+          res();
+        }, 100);
+      });
     });
 
     it("should send message back to admin when message is not recognized", async () => {

--- a/test/reporting.integration.ts
+++ b/test/reporting.integration.ts
@@ -6,7 +6,7 @@ import connect from "../src/services/mongodb.js";
 import MessageHandler from "../src/server/messageHandler.js";
 import messenger from "../src/services/messenger.js";
 import { Entity } from "../src/model/entities.js";
-import { Request, response } from "express";
+import { Request } from "express";
 import { Document } from "mongodb";
 import { mockRequest, mockResponse } from "mock-req-res";
 
@@ -170,6 +170,8 @@ describe("Reporting Tests", function () {
     const endDate = new Date();
     endDate.setHours(endDate.getHours() + 24);
 
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
     const reportArr = await messageHandler.models.reporting.findByDateRange({
       entityId: entityId as string,
       startDate,
@@ -250,6 +252,7 @@ describe("Reporting Tests", function () {
     const endDate = new Date();
     endDate.setHours(endDate.getHours() + 48);
 
+    await new Promise((resolve) => setTimeout(resolve, 100));
     const reportArr = await messageHandler.models.reporting.findByDateRange({
       entityId: entityId as string,
       startDate,
@@ -311,6 +314,7 @@ describe("Reporting Tests", function () {
     const endDate = new Date();
     endDate.setHours(endDate.getHours() + 48);
 
+    await new Promise((resolve) => setTimeout(resolve, 100));
     const reportArr: Document[] = await messageHandler.models.reporting.aggregateByDateRange({
       entityId: entityId as string,
       startDate,


### PR DESCRIPTION
This PR makes it so that when a message is send to a campaign it responds immediately that the messages are being sent. 

Prior to this change it was waiting to complete before responding which led to timed out requests which led to admins not realizing it was currently sending. I also batched the database operations when sending messages. 

Also some DRY refactoring.